### PR TITLE
Created blank view on comparison tab.  Compare button displays swaps

### DIFF
--- a/app/src/main/java/gac/coolteamname/fundnominal/ComparisonFragment.java
+++ b/app/src/main/java/gac/coolteamname/fundnominal/ComparisonFragment.java
@@ -7,6 +7,7 @@ package gac.coolteamname.fundnominal;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -29,13 +30,27 @@ public class ComparisonFragment extends Fragment {
     private SwapAdapter mAdapter;
     private TextView mSwapsText;
     private Button mCompareButton;
+    private TextView mBlankView;
+    private boolean mIsViewShown;
+
+    @Override
+    public void setUserVisibleHint(boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        if (getView() != null) {
+            mIsViewShown = true;
+            mSwapRecyclerView.setVisibility(View.GONE);
+            mBlankView.setVisibility(View.VISIBLE);
+            mCompareButton.setVisibility(View.VISIBLE);
+        } else {
+            mIsViewShown = false;
+        }
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         setHasOptionsMenu(true);
-
     }
 
     @Override
@@ -50,7 +65,9 @@ public class ComparisonFragment extends Fragment {
         mSwapRecyclerView = (RecyclerView) view
                 .findViewById(R.id.swap_recycler_view);
         mSwapRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+        mSwapRecyclerView.setVisibility(View.INVISIBLE);
 
+        mBlankView = (TextView) view.findViewById(R.id.blank_view);
 
         mCompareButton = (Button) view.findViewById(R.id.compare_button);
         mCompareButton.setOnClickListener(new View.OnClickListener() {
@@ -65,7 +82,6 @@ public class ComparisonFragment extends Fragment {
 
         return view;
     }
-
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -104,7 +120,6 @@ public class ComparisonFragment extends Fragment {
             mSwap = swap;
             mSwapTextView.setText(swap);
         }
-
     }
 
     private class SwapAdapter extends RecyclerView.Adapter<SwapHolder> {
@@ -169,10 +184,14 @@ public class ComparisonFragment extends Fragment {
             if (comparisons.isEmpty()) {
                 // If there is no swap, hide RecyclerView, display message
                 mSwapRecyclerView.setVisibility(View.GONE);
+                mBlankView.setVisibility(View.VISIBLE);
+                mCompareButton.setVisibility(View.VISIBLE);
             }
             else {
                 // If there are swap(s), hide message, display RecyclerView
                 mSwapRecyclerView.setVisibility(View.VISIBLE);
+                mBlankView.setVisibility(View.GONE);
+                mCompareButton.setVisibility(View.GONE);
             }
         }
     }

--- a/app/src/main/java/gac/coolteamname/fundnominal/MainActivity.java
+++ b/app/src/main/java/gac/coolteamname/fundnominal/MainActivity.java
@@ -135,7 +135,9 @@ public class MainActivity extends AppCompatActivity implements ActionBar.TabList
             }
             return null;
         }
+
     }
+
 
     /**
      * DOES NOT DO ANYTHING YET

--- a/app/src/main/res/layout/fragment_swap_list.xml
+++ b/app/src/main/res/layout/fragment_swap_list.xml
@@ -19,6 +19,11 @@
         android:layout_below="@+id/swap_text_view">
     </android.support.v7.widget.RecyclerView>
 
+    <TextView
+        android:id="@+id/blank_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <Button android:id="@+id/compare_button"
             android:layout_height="wrap_content" android:layout_width="fill_parent"
             android:layout_alignParentBottom="true"


### PR DESCRIPTION
No conflicts.  Just added a blank view that show up when you switch to the comparison tab, so that the user must press the comparison button to get the most updated trade options and ratings.
